### PR TITLE
Now, there's a list of invalid names for algorithms. 

### DIFF
--- a/src/helpers/algorithm.js
+++ b/src/helpers/algorithm.js
@@ -1,6 +1,7 @@
 // This function handles the algorithm related functions
 
 var { pool } = require('./config');
+alert = require('alert');
 
 const Algorithm = {
 
@@ -17,6 +18,16 @@ const Algorithm = {
     var published_checkbox = req.body.published;
     var published = false;
     var doi = null;
+
+    var not_allowed_names = ["CloudletSchedulerTimeShared", "CloudletSchedulerSpaceShared", 
+      "CloudletSchedulerNull", "CloudletSchedulerCompletelyFair", "CloudletSchedulerAbstract", 
+    "CloudletScheduler"];
+
+    if (not_allowed_names.includes(algorithm_name)){
+      console.log('Not allowed name')
+      alert('This algorithm name is now allowed, please re-upload with a different name!');
+      return
+    }
 
     if(published_checkbox != null){
       doi = req.body.doi;
@@ -42,6 +53,7 @@ const Algorithm = {
         'INSERT INTO development(researcher_id, algorithm_id) VALUES ($1, $2) RETURNING *;',
         [req.session.user_id, rows[0].id]);
 
+        return true;
     } catch(error){
       console.log(error);
     }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -91,6 +91,14 @@
         }
       }
     },
+    "alert": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/alert/-/alert-5.0.0.tgz",
+      "integrity": "sha512-wBxRKKdbeykd1c1IOssidnyiex5UZbBCtA2nT/OraNvLvQJoYT7VM4BusSCTIzun9zjJWIqZkm03j7QIJAAYuQ==",
+      "requires": {
+        "is-program-installed": "2.0.9"
+      }
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -842,6 +850,11 @@
       "requires": {
         "number-is-nan": "^1.0.0"
       }
+    },
+    "is-program-installed": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is-program-installed/-/is-program-installed-2.0.9.tgz",
+      "integrity": "sha512-BmP8AIYqoNxJy3pEwmVX7kYeG/JGR/7ZjqooG6yS0J1zsnskna5KOb3RNxNdnOw4Yc3xdMJQLxoZsVjRnUGQSg=="
     },
     "is-promise": {
       "version": "2.2.2",

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
   "author": "Tiago Toledo Jr",
   "license": "ISC",
   "dependencies": {
+    "alert": "^5.0.0",
     "bcrypt": "^3.0.7",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
For now, the cloudlet schedulers already available on the cloudsim package names are restricted. Used alert package to create a pop-up that informs the user that this name is not allowed as asks him to re-upload with a different name.

closes #9 